### PR TITLE
Add line_breaks option to allow printing line breaks

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -66,6 +66,11 @@ results = nr.run(task=greet_and_count, number=10)
 
 print_result(results)
 print_result(results, vars=["diff", "result", "name", "exception", "severity_level"])
+print_result(
+    results,
+    vars=["diff", "result", "name", "exception", "severity_level"],
+    line_breaks=True,
+)
 print_failed_hosts(results)
 
 print_inventory(nr)

--- a/nornir_rich/functions.py
+++ b/nornir_rich/functions.py
@@ -10,7 +10,6 @@ from nornir.core.task import AggregatedResult, MultiResult, Result
 from rich import print
 from rich.columns import Columns
 from rich.panel import Panel
-from rich.scope import render_scope
 from rich.padding import PaddingDimensions
 from rich.pretty import Pretty
 from rich.protocol import is_renderable, rich_cast

--- a/nornir_rich/functions.py
+++ b/nornir_rich/functions.py
@@ -1,7 +1,7 @@
 import logging
 import threading
-from typing import Any, List, Union, Dict, Optional
-from rich.console import RenderableType
+from typing import Any, List, Union, Dict, Tuple, Optional
+from rich.console import RenderableType, ConsoleRenderable
 
 from nornir.core import Nornir
 from nornir.core.inventory import Inventory
@@ -14,6 +14,8 @@ from rich.scope import render_scope
 from rich.padding import PaddingDimensions
 from rich.pretty import Pretty
 from rich.protocol import is_renderable, rich_cast
+from rich.table import Table
+from rich.text import Text
 
 
 LOCK = threading.Lock()
@@ -31,6 +33,7 @@ class RichHelper:
       vars: Which attributes you want to print
       severity_level: Print only errors with this severity level or higher
       failed: if ``True`` assume the task failed
+      line_breaks: if ``True`` line breaks in strings will be printed
     """
 
     def __init__(
@@ -42,6 +45,7 @@ class RichHelper:
         vars: Optional[List[str]] = None,
         severity_level: int = 0,
         failed: Optional[bool] = None,
+        line_breaks: Optional[bool] = None,
     ) -> None:
         self.columns_settings = columns_settings
         self.columns_settings["expand"] = expand
@@ -51,6 +55,7 @@ class RichHelper:
         self.vars = vars
         self.severity_level = severity_level
         self.failed = failed
+        self.line_breaks = line_breaks
 
     def print_aggregated_result(self, result: AggregatedResult) -> Panel:
         """
@@ -110,7 +115,7 @@ class RichHelper:
             return None
         if self.vars:
             return Panel(
-                render_scope({x: getattr(result, x) for x in self.vars}),
+                self._scope_talbe(scope={x: getattr(result, x) for x in self.vars}),
                 title=result.name,
                 style="red" if result.failed else "green",
             )
@@ -129,13 +134,15 @@ class RichHelper:
     def print_scopes(self, scopes: Dict[str, Any]) -> Columns:
         if self.vars:
             columns = [
-                render_scope(
+                self._scope_talbe(
                     {k: v for k, v in map.items() if k in self.vars}, title=name
                 )
                 for name, map in scopes.items()
             ]
         else:
-            columns = [render_scope(map, title=name) for name, map in scopes.items()]
+            columns = [
+                self._scope_talbe(map, title=name) for name, map in scopes.items()
+            ]
         return Columns(
             columns,
             **self.columns_settings,
@@ -161,6 +168,54 @@ class RichHelper:
             return self.print_result(result)
         return Panel(f"Unable to find printer function for {result}")
 
+    def _scope_talbe(
+        self,
+        scope: "Dict[str, Any]",
+        title: Optional[str] = None,
+    ) -> Panel:
+        """Render python variables in a given scope.
+
+        ***This code is heavily inspired/copied by/from nornir.scope.render_scope***
+        https://github.com/Textualize/rich/blob/master/rich/scope.py
+
+        Args:
+            scope (Dict[str, Any]): A mapping containing variable names and values.
+
+        Returns:
+            Panel: Panel containing the table with key value mapping
+        """
+        items_table = Table.grid(padding=(0, 1), expand=False)
+        items_table.add_column(justify="right")
+
+        def sort_items(item: Tuple[str, Any]) -> Tuple[bool, str]:
+            """Sort special variables first, then alphabetically."""
+            key, _ = item
+            return (not key.startswith("__"), key.lower())
+
+        items = sorted(scope.items(), key=sort_items)
+
+        for key, value in items:
+            key_text = Text.assemble(
+                (key, "scope.key.special" if key.startswith("__") else "scope.key"),
+                (" =", "scope.equals"),
+            )
+
+            if self.line_breaks and isinstance(value, str):
+                value_text: ConsoleRenderable = Text(value.strip())
+            else:
+                value_text = Pretty(value)
+
+            items_table.add_row(
+                key_text,
+                value_text,
+            )
+        return Panel.fit(
+            items_table,
+            title=title,
+            border_style="scope.border",
+            padding=(0, 1),
+        )
+
 
 def print_result(
     result: Union[Result, MultiResult, AggregatedResult],
@@ -171,6 +226,7 @@ def print_result(
     padding: Optional[PaddingDimensions] = None,
     expand: bool = False,
     equal: bool = True,
+    line_breaks: bool = False,
 ) -> None:
     """
     Prints an object of type `nornir.core.task.Result` || `nornir.core.task.MultiResult` || `nornir.core.task.AggregatedResult`
@@ -184,6 +240,7 @@ def print_result(
       padding: Optional padding around cells. Defaults to (0, 1).
       expand: Expand columns to full width. Defaults to False.
       equal: Equal sized columns. Defaults to False
+      line_breaks: if ``True`` line breaks in strings will be printed
     """
     LOCK.acquire()
     equal = False if expand else equal
@@ -195,6 +252,7 @@ def print_result(
         vars=vars,
         severity_level=severity_level,
         failed=failed,
+        line_breaks=line_breaks,
     )
     try:
         if isinstance(result, AggregatedResult):
@@ -216,6 +274,7 @@ def print_failed_hosts(
     padding: Optional[PaddingDimensions] = None,
     expand: bool = False,
     equal: bool = True,
+    line_breaks: bool = False,
 ) -> None:
     """
     Prints results of all failed hosts from `nornir.core.task.AggregatedResult`
@@ -229,6 +288,7 @@ def print_failed_hosts(
       padding: Optional padding around cells. Defaults to (0, 1).
       expand: Expand columns to full width. Defaults to False.
       equal: Equal sized columns. Defaults to False
+      line_breaks: if ``True`` line breaks in strings will be printed
     """
     LOCK.acquire()
     equal = False if expand else equal
@@ -240,6 +300,7 @@ def print_failed_hosts(
         vars=vars,
         severity_level=severity_level,
         failed=failed,
+        line_breaks=line_breaks,
     )
     try:
         for host, multi_result in result.failed_hosts.items():

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -30,6 +30,15 @@ def result_two(host_one: Host) -> Result:
 
 
 @pytest.fixture
+def result_three(host_one: Host) -> Result:
+    return Result(
+        host=host_one,
+        result="Demo result three\nHas a new line",
+        diff="changed 'two' to 'three'\n",
+    )
+
+
+@pytest.fixture
 def result_failed_one(host_one: Host) -> Result:
     return Result(host=host_one, result="Demo failed result", failed=True)
 
@@ -137,6 +146,34 @@ def test_print_result_one_vars(
     result_name: str, expected: str, request: pytest.FixtureRequest
 ) -> None:
     panel = RichHelper(vars=["result", "diff"]).print_result(
+        request.getfixturevalue(result_name)
+    )
+    output = render(panel)
+    assert output == expected
+
+
+@pytest.mark.parametrize(
+    "result_name,expected",
+    [
+        (
+            "result_one",
+            "╭────────────────────────────────────────────────╮\n│ ╭──────────────────────────╮                   │\n│ │   diff =                 │                   │\n│ │ result = Demo result one │                   │\n│ ╰──────────────────────────╯                   │\n╰────────────────────────────────────────────────╯\n",
+        ),
+        (
+            "result_two",
+            "╭────────────────────────────────────────────────╮\n│ ╭─────────────────────────────────╮            │\n│ │   diff = changed 'one' to 'two' │            │\n│ │ result = Demo result two        │            │\n│ ╰─────────────────────────────────╯            │\n╰────────────────────────────────────────────────╯\n",
+        ),
+        (
+            "result_three",
+            "╭────────────────────────────────────────────────╮\n│ ╭───────────────────────────────────╮          │\n│ │   diff = changed 'two' to 'three' │          │\n│ │ result = Demo result three        │          │\n│ │          Has a new line           │          │\n│ ╰───────────────────────────────────╯          │\n╰────────────────────────────────────────────────╯\n",
+        ),
+    ],
+    ids=["result_one", "result_two", "result_three"],
+)
+def test_print_result_vars_line_breaks(
+    result_name: str, expected: str, request: pytest.FixtureRequest
+) -> None:
+    panel = RichHelper(vars=["result", "diff"], line_breaks=True).print_result(
         request.getfixturevalue(result_name)
     )
     output = render(panel)


### PR DESCRIPTION
Closes: #8 

Adding the argument `line_breaks` to be able to print line breaks in scopes. An example can be found in `demo.py`.

![image](https://github.com/InfrastructureAsCode-ch/nornir_rich/assets/2352402/99f35cd0-3a39-4b28-8bc8-a73d4fd91fd9)
